### PR TITLE
Update for Zig 0.15: build API and ABI fixes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -10,7 +10,11 @@ pub fn build(b: *std.Build) void {
     b.installArtifact(lib);
 
     var main_tests = b.addTest(.{
-        .root_source_file = b.path("src/test.zig"),
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/test.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     main_tests.linkLibrary(lib);
     main_tests.addIncludePath(b.path("croaring"));
@@ -21,9 +25,11 @@ pub fn build(b: *std.Build) void {
 
     var example = b.addExecutable(.{
         .name = "example",
-        .root_source_file = b.path("src/example.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/example.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     example.linkLibrary(lib);
     example.addIncludePath(b.path("croaring"));
@@ -34,12 +40,15 @@ pub fn build(b: *std.Build) void {
 }
 
 /// Add Roaring Bitmaps to your build process
-pub fn add(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.Mode) *std.Build.Step.Compile {
-    var lib = b.addStaticLibrary(.{
+pub fn add(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode) *std.Build.Step.Compile {
+    var lib = b.addLibrary(.{
         .name = "roaring-zig",
-        .root_source_file = b.path("src/roaring.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/roaring.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+        .linkage = .static,
     });
 
     lib.addCSourceFile(.{ .file = b.path("croaring/roaring.c"), .flags = &.{} });

--- a/src/roaring.zig
+++ b/src/roaring.zig
@@ -25,7 +25,7 @@ pub const RoaringError = error{
 };
 
 ///
-pub const IteratorFunction = fn (u32, ?*anyopaque) callconv(.C) bool;
+pub const IteratorFunction = fn (u32, ?*anyopaque) callconv(.c) bool;
 
 /// Contains the following u32 fields:
 ///    n_containers               // number of containers
@@ -709,7 +709,7 @@ pub const Bitmap = extern struct {
 ///  frozenSerialize/frozenView
 pub fn allocForFrozen(allocator: std.mem.Allocator, len: usize) ![]align(32) u8 {
     // The buffer must be 32-byte aligned and sized exactly
-    return allocator.alignedAlloc(u8, 32, // alignment
+    return allocator.alignedAlloc(u8, std.mem.Alignment.fromByteUnits(32), // alignment
         len);
 }
 
@@ -817,10 +817,10 @@ export fn roaringAlignedMalloc(ptr_align: usize, size: usize) ?*anyopaque {
         // Allocator's alignment parameter has to be comptime known, so we
         //  have to do this somewhat awkward transform:
         switch (ptr_align) {
-            8 => ally.alignedAlloc(u8, 8, size),
-            16 => ally.alignedAlloc(u8, 16, size),
+            8 => ally.alignedAlloc(u8, std.mem.Alignment.fromByteUnits(8), size),
+            16 => ally.alignedAlloc(u8, std.mem.Alignment.fromByteUnits(16), size),
             // This appears to be the only value that is actually used in roaring.c
-            32 => ally.alignedAlloc(u8, 32, size),
+            32 => ally.alignedAlloc(u8, std.mem.Alignment.fromByteUnits(32), size),
             else => @panic("Unexpected alignment size"),
         } catch return null);
     }

--- a/src/test.zig
+++ b/src/test.zig
@@ -309,7 +309,7 @@ test "catch 'em all" {
     _ = it.read(vals[0..]);
 }
 
-fn iterate_sum(value: u32, data: ?*anyopaque) callconv(.C) bool {
+fn iterate_sum(value: u32, data: ?*anyopaque) callconv(.c) bool {
     const ptr: *u32 = @ptrCast(@alignCast(data));
     ptr.* += value;
     return true;


### PR DESCRIPTION
## Summary
- Switch to `std.builtin.OptimizeMode`
- Migrate `build.zig` to Zig 0.15 `std.Build` API: use `root_module` via `b.createModule`, and `b.addLibrary` with static linkage.
- Update allocator `alignedAlloc` calls to pass `std.mem.Alignment`.
- Update calling conventions to `callconv(.c)`.

## Motivation
Enable building and testing with Zig 0.15. Verified `zig build`, `zig build test`, and `zig build run-example` succeed locally.

## Notes
No changes to public API beyond calling convention constant; behavior compatible.