### PR TITLE
Add microbench runner matching CRoaring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ zig-out/
 deps.zig
 .zig-cache
 tmp
+build/
+src/example
+src/test

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tmp
 build/
 src/example
 src/test
+/tmp-croaring

--- a/README.md
+++ b/README.md
@@ -198,3 +198,23 @@ defer on_the_stack.clear(); // the contents are dynamic, free by clearing
 var result = dynamic._or(&on_the_stack);
 defer result.free(); // operation results are always dynamic
 ```
+
+## Running microbenchmarks
+
+We provide a small microbenchmark runner similar to CRoaring's.
+
+- Build and run with the default dataset (tries `~/source/CRoaring/benchmarks/realdata/census1881`):
+
+```bash
+zig build -Doptimize=ReleaseFast bench
+```
+
+- Or pass a dataset directory (must contain `.txt` files with comma-separated integers):
+
+```bash
+zig build -Doptimize=ReleaseFast bench -- /path/to/CRoaring/benchmarks/realdata/census1881
+```
+
+Notes:
+- Use `-Doptimize=ReleaseFast` for numbers comparable to CRoaring's C/C++ builds.
+- Keep the command on a single line after `--`. If you press Enter before the path, your shell may try to execute the path and report "permission denied".

--- a/README.md
+++ b/README.md
@@ -223,3 +223,54 @@ Notes:
 ```bash
 zig build -Doptimize=ReleaseFast bench -- /path/to/dataset --bench Array
 ```
+
+### Compare with CRoaring microbenchmarks (C vs Zig)
+
+Use the helper script to clone/update CRoaring, build its C microbenchmarks with zig cc/c++, run both C and Zig benches on the same dataset, and print a comparison table by benchmark name using only the Time (ns) column.
+
+- Basic (clones into `/tmp/CRoaring` if not set via `CROARING_DIR`, uses `census1881` dataset):
+
+```bash
+./run_croaring_microbench.sh
+```
+
+- Run against a specific dataset directory inside CRoaring:
+
+```bash
+./run_croaring_microbench.sh "/tmp/CRoaring/benchmarks/realdata/census-income"
+./run_croaring_microbench.sh "/tmp/CRoaring/benchmarks/realdata/uscensus2000"
+```
+
+- If your CRoaring clone lives elsewhere, set `CROARING_DIR` (the first positional argument is still the dataset directory):
+
+```bash
+CROARING_DIR="/path/to/CRoaring" \
+  ./run_croaring_microbench.sh \
+  "$CROARING_DIR/benchmarks/realdata/census1881"
+```
+
+- Pass google-benchmark filters to the CRoaring side (e.g., to run only union-related benches):
+
+```bash
+./run_croaring_microbench.sh "/tmp/CRoaring/benchmarks/realdata/census1881" \
+  --benchmark_filter=SuccessiveUnion.*
+```
+
+- Batch across all datasets:
+
+```bash
+CROARING_DIR="${CROARING_DIR:-$HOME/source/CRoaring}"
+for d in "$CROARING_DIR"/benchmarks/realdata/*; do
+  [ -d "$d" ] && ./run_croaring_microbench.sh "$d"
+done
+```
+
+The script prints a table like:
+
+```
+Benchmark                            CRoaring(ns)        Zig(ns)     Zig/CR
+---------                             -----------        -------      -----
+SuccessiveIntersection                      20276           19524      0.96x
+...
+```
+

--- a/README.md
+++ b/README.md
@@ -218,3 +218,8 @@ zig build -Doptimize=ReleaseFast bench -- /path/to/CRoaring/benchmarks/realdata/
 Notes:
 - Use `-Doptimize=ReleaseFast` for numbers comparable to CRoaring's C/C++ builds.
 - Keep the command on a single line after `--`. If you press Enter before the path, your shell may try to execute the path and report "permission denied".
+- To run only a subset, filter by substring with `--bench` (or `-b`):
+
+```bash
+zig build -Doptimize=ReleaseFast bench -- /path/to/dataset --bench Array
+```

--- a/build.zig
+++ b/build.zig
@@ -61,13 +61,22 @@ pub fn build(b: *std.Build) void {
         }),
     });
     // Allow bench to import the Zig roaring wrapper as `@import("roaring")`
-    const roaring_mod = b.createModule(.{
+    const roaring_mod = b.addModule("roaring_mod", .{
         .root_source_file = b.path("src/roaring.zig"),
         .target = target,
         .optimize = optimize,
     });
     roaring_mod.addIncludePath(b.path("croaring"));
     bench.root_module.addImport("roaring", roaring_mod);
+    // And 64-bit wrapper
+    const roaring64_mod = b.addModule("roaring64_mod", .{
+        .root_source_file = b.path("src/roaring64.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    roaring64_mod.addIncludePath(b.path("croaring"));
+    roaring64_mod.addImport("roaring", roaring_mod);
+    bench.root_module.addImport("roaring64", roaring64_mod);
     // Compile CRoaring C source into the bench so Zig wrapper can link
     bench.addCSourceFile(.{ .file = b.path("croaring/roaring.c"), .flags = &.{} });
     bench.addIncludePath(b.path("croaring"));

--- a/build.zig
+++ b/build.zig
@@ -82,6 +82,10 @@ pub fn build(b: *std.Build) void {
     bench.addIncludePath(b.path("croaring"));
     bench.linkLibC();
     const run_bench = b.addRunArtifact(bench);
+    // forward args passed after `--` to the bench executable
+    if (b.args) |cli_args| {
+        run_bench.addArgs(cli_args);
+    }
     // Allow passing a dataset directory like: zig build bench -- <dir>
     const bench_step = b.step("bench", "Run microbenchmarks (optionally pass a data dir)");
     bench_step.dependOn(&run_bench.step);

--- a/microbench/bench.zig
+++ b/microbench/bench.zig
@@ -1,9 +1,11 @@
 const std = @import("std");
 const roaring = @import("roaring");
+const roaring64 = @import("roaring64");
 
 const DataSet = struct {
     allocator: std.mem.Allocator,
     bitmaps32: []*roaring.Bitmap,
+    bitmaps64: []*roaring64.Bitmap64,
     max_value: u32,
     max_cardinality: usize,
 };
@@ -87,8 +89,9 @@ fn parseU32List(allocator: std.mem.Allocator, bytes: []const u8) ![]u32 {
     return nums;
 }
 
-fn buildBitmaps32(allocator: std.mem.Allocator, all_numbers: [][]u32) !DataSet {
+fn buildBitmaps(allocator: std.mem.Allocator, all_numbers: [][]u32) !DataSet {
     var bitmaps = try allocator.alloc(*roaring.Bitmap, all_numbers.len);
+    var bitmaps64 = try allocator.alloc(*roaring64.Bitmap64, all_numbers.len);
     var max_value: u32 = 0;
     var max_card: usize = 0;
     for (all_numbers, 0..) |nums, i| {
@@ -96,16 +99,26 @@ fn buildBitmaps32(allocator: std.mem.Allocator, all_numbers: [][]u32) !DataSet {
             if (nums[nums.len - 1] > max_value) max_value = nums[nums.len - 1];
         }
         if (nums.len > max_card) max_card = nums.len;
+
         bitmaps[i] = try roaring.Bitmap.fromSlice(nums);
         _ = bitmaps[i].runOptimize();
         _ = bitmaps[i].shrinkToFit();
+
+        bitmaps64[i] = try roaring64.Bitmap64.create();
+        var j: usize = 0;
+        while (j < nums.len) : (j += 1) {
+            bitmaps64[i].add(nums[j]);
+        }
+        _ = bitmaps64[i].runOptimize();
     }
-    return .{ .allocator = allocator, .bitmaps32 = bitmaps, .max_value = max_value, .max_cardinality = max_card };
+    return .{ .allocator = allocator, .bitmaps32 = bitmaps, .bitmaps64 = bitmaps64, .max_value = max_value, .max_cardinality = max_card };
 }
 
-fn freeBitmaps32(ds: *DataSet) void {
+fn freeBitmaps(ds: *DataSet) void {
     for (ds.bitmaps32) |bm| bm.free();
+    for (ds.bitmaps64) |bm| bm.free();
     ds.allocator.free(ds.bitmaps32);
+    ds.allocator.free(ds.bitmaps64);
 }
 
 fn runBenchmarks(allocator: std.mem.Allocator, ds: *const DataSet) !void {
@@ -115,32 +128,54 @@ fn runBenchmarks(allocator: std.mem.Allocator, ds: *const DataSet) !void {
     // List of benches: name, function pointer
     const Entry = struct { name: []const u8, func: *const fn (*const DataSet) u64 };
     const benches = [_]Entry{
+        .{ .name = "SuccessiveIntersection", .func = bench_successive_intersection },
+        .{ .name = "SuccessiveIntersection64", .func = bench_successive_intersection64 },
         .{ .name = "SuccessiveIntersectionCardinality", .func = bench_successive_intersection_cardinality },
+        .{ .name = "SuccessiveIntersectionCardinality64", .func = bench_successive_intersection_cardinality64 },
         .{ .name = "SuccessiveUnionCardinality", .func = bench_successive_union_cardinality },
+        .{ .name = "SuccessiveUnionCardinality64", .func = bench_successive_union_cardinality64 },
         .{ .name = "SuccessiveDifferenceCardinality", .func = bench_successive_difference_cardinality },
+        .{ .name = "SuccessiveDifferenceCardinality64", .func = bench_successive_difference_cardinality64 },
+        .{ .name = "SuccessiveUnion", .func = bench_successive_union },
+        .{ .name = "SuccessiveUnion64", .func = bench_successive_union64 },
+        .{ .name = "TotalUnion", .func = bench_total_union },
+        .{ .name = "TotalUnionHeap", .func = bench_total_union_heap },
         .{ .name = "RandomAccess", .func = bench_random_access },
+        .{ .name = "RandomAccess64", .func = bench_random_access64 },
         .{ .name = "ComputeCardinality", .func = bench_compute_cardinality },
+        .{ .name = "ComputeCardinality64", .func = bench_compute_cardinality64 },
+        .{ .name = "RankManySlow", .func = bench_rank_many_slow },
+        .{ .name = "RankMany", .func = bench_rank_many },
+        .{ .name = "ToArray", .func = bench_to_array },
+        .{ .name = "ToArray64", .func = bench_to_array64 },
         .{ .name = "IterateAll", .func = bench_iterate_all },
+        .{ .name = "IterateAll64", .func = bench_iterate_all64 },
     };
 
-    std.debug.print("\n", .{});
-    std.debug.print("benchmark\ttime_ns\tmarker\n", .{});
+    std.debug.print("------------------------------------------------------------------------------\n", .{});
+    std.debug.print("Benchmark                                    Time             CPU   Iterations\n", .{});
+    std.debug.print("------------------------------------------------------------------------------\n", .{});
 
     for (benches) |b| {
-        // Run a few times and take best (min) to reduce noise
-        var best: u64 = std.math.maxInt(u64);
-        var best_marker: u64 = 0;
-        var rep: usize = 0;
-        while (rep < 5) : (rep += 1) {
-            var t = std.time.Timer.start() catch unreachable;
-            const marker = b.func(ds);
-            const elapsed = t.read();
-            if (elapsed < best) {
-                best = elapsed;
-                best_marker = marker;
-            }
+        var total_ns: u64 = 0;
+        var iterations: u64 = 0;
+        var marker_sum: u64 = 0;
+        const target_total_ns: u64 = 1_000_000_000; // 1s per benchmark
+
+        // one warm-up
+        marker_sum += b.func(ds);
+
+        var timer = std.time.Timer.start() catch unreachable;
+        while (true) {
+            marker_sum += b.func(ds);
+            iterations += 1;
+            total_ns = timer.read();
+            if (total_ns >= target_total_ns) break;
         }
-        std.debug.print("{s}\t{d}\t{d}\n", .{ b.name, best, best_marker });
+        const avg_ns: u64 = if (iterations > 0) total_ns / iterations else 0;
+        std.debug.print("{s:<42}{d:12} ns {d:12} ns {d:12}\n", .{ b.name, avg_ns, avg_ns, iterations });
+        // prevent optimizer from removing work
+        if (marker_sum == 0xDEADBEEFDEADBEEF) @panic("impossible");
     }
     _ = allocator; // reserved for future counters
 }
@@ -163,11 +198,64 @@ fn bench_successive_union_cardinality(ds: *const DataSet) u64 {
     return marker;
 }
 
+fn bench_successive_intersection(ds: *const DataSet) u64 {
+    var marker: u64 = 0;
+    var i: usize = 0;
+    while (i + 1 < ds.bitmaps32.len) : (i += 1) {
+        var tmp = ds.bitmaps32[i]._and(ds.bitmaps32[i + 1]) catch unreachable;
+        marker += tmp.cardinality();
+        tmp.free();
+    }
+    return marker;
+}
+
+fn bench_successive_intersection64(ds: *const DataSet) u64 {
+    var marker: u64 = 0;
+    var i: usize = 0;
+    while (i + 1 < ds.bitmaps64.len) : (i += 1) {
+        var tmp = ds.bitmaps64[i]._and(ds.bitmaps64[i + 1]) catch unreachable;
+        marker += tmp.cardinality();
+        tmp.free();
+    }
+    return marker;
+}
+
+fn bench_successive_intersection_cardinality64(ds: *const DataSet) u64 {
+    var marker: u64 = 0;
+    var i: usize = 0;
+    while (i + 1 < ds.bitmaps64.len) : (i += 1) {
+        marker += ds.bitmaps64[i]._andCardinality(ds.bitmaps64[i + 1]);
+    }
+    return marker;
+}
+
 fn bench_successive_difference_cardinality(ds: *const DataSet) u64 {
     var marker: u64 = 0;
     var i: usize = 0;
     while (i + 1 < ds.bitmaps32.len) : (i += 1) {
         marker += ds.bitmaps32[i]._andnotCardinality(ds.bitmaps32[i + 1]);
+    }
+    return marker;
+}
+
+fn bench_successive_union(ds: *const DataSet) u64 {
+    var marker: u64 = 0;
+    var i: usize = 0;
+    while (i + 1 < ds.bitmaps32.len) : (i += 1) {
+        var tmp = ds.bitmaps32[i]._or(ds.bitmaps32[i + 1]) catch unreachable;
+        marker += tmp.cardinality();
+        tmp.free();
+    }
+    return marker;
+}
+
+fn bench_successive_union64(ds: *const DataSet) u64 {
+    var marker: u64 = 0;
+    var i: usize = 0;
+    while (i + 1 < ds.bitmaps64.len) : (i += 1) {
+        var tmp = ds.bitmaps64[i]._or(ds.bitmaps64[i + 1]) catch unreachable;
+        marker += tmp.cardinality();
+        tmp.free();
     }
     return marker;
 }
@@ -183,9 +271,34 @@ fn bench_random_access(ds: *const DataSet) u64 {
     return marker;
 }
 
+fn bench_random_access64(ds: *const DataSet) u64 {
+    var marker: u64 = 0;
+    const mv = ds.max_value;
+    for (ds.bitmaps64) |bm| {
+        if (bm.contains(mv / 4)) marker += 1;
+        if (bm.contains(mv / 2)) marker += 1;
+        if (bm.contains(mv - mv / 4)) marker += 1;
+    }
+    return marker;
+}
+
+extern fn cpp_random_access64(handle: ?*const anyopaque, maxvalue: u32) callconv(.c) u64;
+
+fn bench_random_access64_cpp(ds: *const DataSet) u64 {
+    return cpp_random_access64(ds.bitmaps64_cpp, ds.max_value);
+}
+
 fn bench_compute_cardinality(ds: *const DataSet) u64 {
     var marker: u64 = 0;
     for (ds.bitmaps32) |bm| {
+        marker += bm.cardinality();
+    }
+    return marker;
+}
+
+fn bench_compute_cardinality64(ds: *const DataSet) u64 {
+    var marker: u64 = 0;
+    for (ds.bitmaps64) |bm| {
         marker += bm.cardinality();
     }
     return marker;
@@ -201,6 +314,122 @@ fn bench_iterate_all(ds: *const DataSet) u64 {
         }
     }
     return marker;
+}
+
+fn bench_iterate_all64(ds: *const DataSet) u64 {
+    var marker: u64 = 0;
+    for (ds.bitmaps64) |bm| {
+        var it = bm.iterator() catch unreachable;
+        defer it.free();
+        while (it.hasValue()) {
+            marker += 1;
+            _ = it.next();
+        }
+    }
+    return marker;
+}
+
+fn bench_to_array(ds: *const DataSet) u64 {
+    var marker: u64 = 0;
+    for (ds.bitmaps32) |bm| {
+        const card = bm.cardinality();
+        var tmp = std.heap.page_allocator.alloc(u32, @intCast(card)) catch unreachable;
+        defer std.heap.page_allocator.free(tmp);
+        // The direct to-array API is in CRoaring C; here we skip for parity.
+        // Use iterator bulk read instead to simulate work
+        var it = bm.iterator();
+        var idx: usize = 0;
+        while (it.hasValue()) {
+            if (idx < tmp.len) tmp[idx] = it.currentValue();
+            idx += 1;
+            _ = it.next();
+        }
+        if (tmp.len > 0) marker += tmp[0];
+    }
+    return marker;
+}
+
+fn bench_to_array64(ds: *const DataSet) u64 {
+    var marker: u64 = 0;
+    for (ds.bitmaps64) |bm| {
+        const card = bm.cardinality();
+        var tmp = std.heap.page_allocator.alloc(u64, @intCast(card)) catch unreachable;
+        defer std.heap.page_allocator.free(tmp);
+        // No direct to-array in wrapper: iterate
+        var it = bm.iterator() catch unreachable;
+        defer it.free();
+        var idx: usize = 0;
+        while (it.hasValue()) {
+            if (idx < tmp.len) tmp[idx] = it.currentValue();
+            idx += 1;
+            _ = it.next();
+        }
+        if (tmp.len > 0) marker += @intCast(tmp[0] & 0xffffffff);
+    }
+    return marker;
+}
+
+fn bench_total_union(ds: *const DataSet) u64 {
+    var marker: u64 = 0;
+    const arr = ds.bitmaps32;
+    var tmp = roaring.Bitmap._orMany(@ptrCast(@constCast(arr))) catch unreachable;
+    marker = tmp.cardinality();
+    tmp.free();
+    return marker;
+}
+
+fn bench_total_union_heap(ds: *const DataSet) u64 {
+    var marker: u64 = 0;
+    const arr = ds.bitmaps32;
+    var tmp = roaring.Bitmap._orManyHeap(@ptrCast(@constCast(arr))) catch unreachable;
+    marker = tmp.cardinality();
+    tmp.free();
+    return marker;
+}
+
+fn bench_successive_difference_cardinality64(ds: *const DataSet) u64 {
+    var marker: u64 = 0;
+    var i: usize = 0;
+    while (i + 1 < ds.bitmaps64.len) : (i += 1) {
+        marker += ds.bitmaps64[i]._andnotCardinality(ds.bitmaps64[i + 1]);
+    }
+    return marker;
+}
+
+fn bench_successive_union_cardinality64(ds: *const DataSet) u64 {
+    var marker: u64 = 0;
+    var i: usize = 0;
+    while (i + 1 < ds.bitmaps64.len) : (i += 1) {
+        marker += ds.bitmaps64[i]._orCardinality(ds.bitmaps64[i + 1]);
+    }
+    return marker;
+}
+
+fn bench_rank_many_slow(ds: *const DataSet) u64 {
+    var ranks: [5]u64 = .{0} ** 5;
+    for (ds.bitmaps32) |bm| {
+        ranks[0] = bm.rank(ds.max_value / 5);
+        ranks[1] = bm.rank(2 * ds.max_value / 5);
+        ranks[2] = bm.rank(3 * ds.max_value / 5);
+        ranks[3] = bm.rank(4 * ds.max_value / 5);
+        ranks[4] = bm.rank(ds.max_value);
+    }
+    return ranks[0];
+}
+
+fn bench_rank_many(ds: *const DataSet) u64 {
+    var ranks: [5]u64 = .{0} ** 5;
+    const input: [5]u32 = .{
+        ds.max_value / 5, 2 * ds.max_value / 5, 3 * ds.max_value / 5, 4 * ds.max_value / 5, ds.max_value,
+    };
+    for (ds.bitmaps32) |bm| {
+        // Use rank in a loop to simulate bulk; CRoaring uses rank_many API
+        var i: usize = 0;
+        while (i < input.len) : (i += 1) {
+            ranks[i] = bm.rank(input[i]);
+        }
+    }
+    return ranks[0];
 }
 
 var global_data_source: ?[]const u8 = null;
@@ -242,9 +471,9 @@ pub fn main() !void {
         return error.NotFound;
     }
 
-    var ds = try buildBitmaps32(allocator, numbers);
+    var ds = try buildBitmaps(allocator, numbers);
     defer {
-        freeBitmaps32(&ds);
+        freeBitmaps(&ds);
         for (numbers) |arr| allocator.free(arr);
         allocator.free(numbers);
         if (global_data_source) |p| allocator.free(p);

--- a/microbench/bench.zig
+++ b/microbench/bench.zig
@@ -159,7 +159,6 @@ fn runBenchmarks(allocator: std.mem.Allocator, ds: *const DataSet, data_source: 
         .{ .name = "ComputeCardinality", .func = bench_compute_cardinality },
         .{ .name = "ComputeCardinality64", .func = bench_compute_cardinality64 },
         .{ .name = "RankManySlow", .func = bench_rank_many_slow },
-        .{ .name = "RankMany", .func = bench_rank_many },
     };
 
     std.debug.print("---------------------------------------------------------------------\n", .{});
@@ -409,21 +408,6 @@ fn bench_rank_many_slow(ds: *const DataSet) u64 {
         ranks[2] = bm.rank(3 * ds.max_value / 5);
         ranks[3] = bm.rank(4 * ds.max_value / 5);
         ranks[4] = bm.rank(ds.max_value);
-    }
-    return ranks[0];
-}
-
-fn bench_rank_many(ds: *const DataSet) u64 {
-    var ranks: [5]u64 = .{0} ** 5;
-    const input: [5]u32 = .{
-        ds.max_value / 5, 2 * ds.max_value / 5, 3 * ds.max_value / 5, 4 * ds.max_value / 5, ds.max_value,
-    };
-    for (ds.bitmaps32) |bm| {
-        // Use rank in a loop to simulate bulk; CRoaring uses rank_many API
-        var i: usize = 0;
-        while (i < input.len) : (i += 1) {
-            ranks[i] = bm.rank(input[i]);
-        }
     }
     return ranks[0];
 }

--- a/microbench/bench.zig
+++ b/microbench/bench.zig
@@ -1,0 +1,254 @@
+const std = @import("std");
+const roaring = @import("roaring");
+
+const DataSet = struct {
+    allocator: std.mem.Allocator,
+    bitmaps32: []*roaring.Bitmap,
+    max_value: u32,
+    max_cardinality: usize,
+};
+
+fn readAllIntegerFiles(allocator: std.mem.Allocator, dir_path: []const u8) ![][]u32 {
+    // First pass: count .txt files
+    var d1 = try std.fs.cwd().openDir(dir_path, .{ .iterate = true });
+    defer d1.close();
+    var count: usize = 0;
+    var it1 = d1.iterate();
+    while (try it1.next()) |entry| {
+        if (entry.kind != .file) continue;
+        if (!std.mem.endsWith(u8, entry.name, ".txt")) continue;
+        count += 1;
+    }
+    // Allocate names array
+    var names = try allocator.alloc([]u8, count);
+    var idx: usize = 0;
+    // Second pass: collect names
+    var d2 = try std.fs.cwd().openDir(dir_path, .{ .iterate = true });
+    defer d2.close();
+    var it2 = d2.iterate();
+    while (try it2.next()) |entry| {
+        if (entry.kind != .file) continue;
+        if (!std.mem.endsWith(u8, entry.name, ".txt")) continue;
+        names[idx] = try allocator.dupe(u8, entry.name);
+        idx += 1;
+    }
+    // Sort names
+    std.mem.sort([]u8, names, {}, struct {
+        fn lt(_: void, a: []u8, b: []u8) bool {
+            return std.mem.lessThan(u8, a, b);
+        }
+    }.lt);
+
+    var out = try allocator.alloc([]u32, names.len);
+    var i: usize = 0;
+    while (i < names.len) : (i += 1) {
+        const name = names[i];
+        const full = try std.fs.path.join(allocator, &.{ dir_path, name });
+        defer allocator.free(full);
+        const bytes = try std.fs.cwd().readFileAlloc(allocator, full, 1 << 28);
+        defer allocator.free(bytes);
+        out[i] = try parseU32List(allocator, bytes);
+    }
+    // free names
+    for (names) |n| allocator.free(n);
+    allocator.free(names);
+    return out;
+}
+
+fn parseU32List(allocator: std.mem.Allocator, bytes: []const u8) ![]u32 {
+    // Count numbers first (sequences of digits)
+    var count: usize = 0;
+    var i: usize = 0;
+    while (i < bytes.len) : (i += 1) {
+        const ch = bytes[i];
+        if (ch >= '0' and ch <= '9') {
+            count += 1;
+            // skip rest of digits
+            i += 1;
+            while (i < bytes.len and (bytes[i] >= '0' and bytes[i] <= '9')) : (i += 1) {}
+        }
+    }
+    var nums = try allocator.alloc(u32, count);
+    var idx: usize = 0;
+    i = 0;
+    while (i < bytes.len) : (i += 1) {
+        const ch = bytes[i];
+        if (ch >= '0' and ch <= '9') {
+            var v: u64 = (ch - '0');
+            i += 1;
+            while (i < bytes.len and (bytes[i] >= '0' and bytes[i] <= '9')) : (i += 1) {
+                v = v * 10 + (bytes[i] - '0');
+            }
+            if (v > std.math.maxInt(u32)) return error.ValueTooLarge;
+            nums[idx] = @intCast(v);
+            idx += 1;
+        }
+    }
+    return nums;
+}
+
+fn buildBitmaps32(allocator: std.mem.Allocator, all_numbers: [][]u32) !DataSet {
+    var bitmaps = try allocator.alloc(*roaring.Bitmap, all_numbers.len);
+    var max_value: u32 = 0;
+    var max_card: usize = 0;
+    for (all_numbers, 0..) |nums, i| {
+        if (nums.len > 0) {
+            if (nums[nums.len - 1] > max_value) max_value = nums[nums.len - 1];
+        }
+        if (nums.len > max_card) max_card = nums.len;
+        bitmaps[i] = try roaring.Bitmap.fromSlice(nums);
+        _ = bitmaps[i].runOptimize();
+        _ = bitmaps[i].shrinkToFit();
+    }
+    return .{ .allocator = allocator, .bitmaps32 = bitmaps, .max_value = max_value, .max_cardinality = max_card };
+}
+
+fn freeBitmaps32(ds: *DataSet) void {
+    for (ds.bitmaps32) |bm| bm.free();
+    ds.allocator.free(ds.bitmaps32);
+}
+
+fn runBenchmarks(allocator: std.mem.Allocator, ds: *const DataSet) !void {
+    std.debug.print("data source: {s}\n", .{global_data_source orelse "(unspecified)"});
+    std.debug.print("number of bitmaps: {d}\n", .{ds.bitmaps32.len});
+
+    // List of benches: name, function pointer
+    const Entry = struct { name: []const u8, func: *const fn (*const DataSet) u64 };
+    const benches = [_]Entry{
+        .{ .name = "SuccessiveIntersectionCardinality", .func = bench_successive_intersection_cardinality },
+        .{ .name = "SuccessiveUnionCardinality", .func = bench_successive_union_cardinality },
+        .{ .name = "SuccessiveDifferenceCardinality", .func = bench_successive_difference_cardinality },
+        .{ .name = "RandomAccess", .func = bench_random_access },
+        .{ .name = "ComputeCardinality", .func = bench_compute_cardinality },
+        .{ .name = "IterateAll", .func = bench_iterate_all },
+    };
+
+    std.debug.print("\n", .{});
+    std.debug.print("benchmark\ttime_ns\tmarker\n", .{});
+
+    for (benches) |b| {
+        // Run a few times and take best (min) to reduce noise
+        var best: u64 = std.math.maxInt(u64);
+        var best_marker: u64 = 0;
+        var rep: usize = 0;
+        while (rep < 5) : (rep += 1) {
+            var t = std.time.Timer.start() catch unreachable;
+            const marker = b.func(ds);
+            const elapsed = t.read();
+            if (elapsed < best) {
+                best = elapsed;
+                best_marker = marker;
+            }
+        }
+        std.debug.print("{s}\t{d}\t{d}\n", .{ b.name, best, best_marker });
+    }
+    _ = allocator; // reserved for future counters
+}
+
+fn bench_successive_intersection_cardinality(ds: *const DataSet) u64 {
+    var marker: u64 = 0;
+    var i: usize = 0;
+    while (i + 1 < ds.bitmaps32.len) : (i += 1) {
+        marker += ds.bitmaps32[i]._andCardinality(ds.bitmaps32[i + 1]);
+    }
+    return marker;
+}
+
+fn bench_successive_union_cardinality(ds: *const DataSet) u64 {
+    var marker: u64 = 0;
+    var i: usize = 0;
+    while (i + 1 < ds.bitmaps32.len) : (i += 1) {
+        marker += ds.bitmaps32[i]._orCardinality(ds.bitmaps32[i + 1]);
+    }
+    return marker;
+}
+
+fn bench_successive_difference_cardinality(ds: *const DataSet) u64 {
+    var marker: u64 = 0;
+    var i: usize = 0;
+    while (i + 1 < ds.bitmaps32.len) : (i += 1) {
+        marker += ds.bitmaps32[i]._andnotCardinality(ds.bitmaps32[i + 1]);
+    }
+    return marker;
+}
+
+fn bench_random_access(ds: *const DataSet) u64 {
+    var marker: u64 = 0;
+    const mv = ds.max_value;
+    for (ds.bitmaps32) |bm| {
+        if (bm.contains(mv / 4)) marker += 1;
+        if (bm.contains(mv / 2)) marker += 1;
+        if (bm.contains(mv - mv / 4)) marker += 1;
+    }
+    return marker;
+}
+
+fn bench_compute_cardinality(ds: *const DataSet) u64 {
+    var marker: u64 = 0;
+    for (ds.bitmaps32) |bm| {
+        marker += bm.cardinality();
+    }
+    return marker;
+}
+
+fn bench_iterate_all(ds: *const DataSet) u64 {
+    var marker: u64 = 0;
+    for (ds.bitmaps32) |bm| {
+        var it = bm.iterator();
+        while (it.hasValue()) {
+            marker += 1;
+            _ = it.next();
+        }
+    }
+    return marker;
+}
+
+var global_data_source: ?[]const u8 = null;
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    const args = try std.process.argsAlloc(allocator);
+    defer std.process.argsFree(allocator, args);
+
+    var data_dir: []const u8 = undefined;
+    if (args.len <= 1 or (args.len > 1 and args[1].len > 0 and args[1][0] == '-')) {
+        // Default to CRoaring realdata census1881 if available
+        const home = std.process.getEnvVarOwned(allocator, "HOME") catch null;
+        if (home) |h| {
+            defer allocator.free(h);
+            const def = try std.fs.path.join(allocator, &.{ h, "source", "CRoaring", "benchmarks", "realdata", "census1881" });
+            defer allocator.free(def);
+            if (std.fs.cwd().openDir(def, .{})) |d| {
+                var dir = d; // make mutable to close
+                dir.close();
+                data_dir = try allocator.dupe(u8, def);
+            } else |_| {
+                data_dir = "."; // fallback
+            }
+        } else {
+            data_dir = ".";
+        }
+    } else {
+        data_dir = args[1];
+    }
+    global_data_source = data_dir;
+
+    const numbers = try readAllIntegerFiles(allocator, data_dir);
+    if (numbers.len == 0) {
+        std.debug.print("No .txt files found in {s}\n", .{data_dir});
+        return error.NotFound;
+    }
+
+    var ds = try buildBitmaps32(allocator, numbers);
+    defer {
+        freeBitmaps32(&ds);
+        for (numbers) |arr| allocator.free(arr);
+        allocator.free(numbers);
+        if (global_data_source) |p| allocator.free(p);
+    }
+
+    try runBenchmarks(allocator, &ds);
+}

--- a/run_croaring_microbench.sh
+++ b/run_croaring_microbench.sh
@@ -7,14 +7,20 @@ set -euo pipefail
 #   ./run_croaring_microbench.sh [DATA_DIR] [google-benchmark args]
 #
 # Notes:
-# - Clones CRoaring into .deps/CRoaring if missing; otherwise updates it.
-# - Builds with CMake in .deps/CRoaring/build-zig using zig cc/c++.
+# - Uses $CROARING_DIR if set; otherwise clones into /tmp/CRoaring.
+# - Builds with CMake in <CROARING_DIR>/build-zig using zig cc/c++.
 # - Builds only the 'bench' target and runs it.
 # - By default, filters out benchmarks whose names contain 'cpp' or 'Cpp'.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CROARING_REMOTE="https://github.com/RoaringBitmap/CRoaring.git"
-CROARING_DIR="$SCRIPT_DIR/tmp-croaring"
+
+# Determine CRoaring directory:
+if [[ -n "${CROARING_DIR:-}" ]]; then
+  CROARING_DIR="$CROARING_DIR"
+else
+  CROARING_DIR="/tmp/CRoaring"
+fi
 BUILD_DIR="$CROARING_DIR/build-zig"
 BUILD_TYPE="Release"
 
@@ -63,8 +69,8 @@ if [[ ! -x "$BENCH_BIN" ]]; then
   exit 1
 fi
 
-# Run benchmarks
-echo "[INFO] Running bench (realdata)"
+# Run CRoaring bench and Zig bench, then compare
+echo "[INFO] Running CRoaring bench (realdata)"
 
 # Parse args: optional first positional DATA_DIR if it is a directory
 DATA_ARG=""
@@ -88,6 +94,38 @@ if [[ $HAS_FILTER -eq 0 ]]; then
   DEFAULT_FILTER='--benchmark_filter=^(SuccessiveIntersection(64|Cardinality(64)?)?|SuccessiveUnion(Cardinality(64)?|64)?|SuccessiveDifferenceCardinality(64)?|TotalUnion(Heap)?|RandomAccess(64)?|ToArray(64)?|IterateAll(64)?|ComputeCardinality(64)?|RankMany(Slow)?)$'
 fi
 
-"$BENCH_BIN" ${DATA_ARG:++"$DATA_ARG"} ${DEFAULT_FILTER:+"$DEFAULT_FILTER"} "$@"
+TMP_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t croaring)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+CROAR_OUT="$TMP_DIR/croaring.txt"
+ZIG_OUT="$TMP_DIR/zig.txt"
+
+"$BENCH_BIN" ${DATA_ARG:++"$DATA_ARG"} ${DEFAULT_FILTER:+"$DEFAULT_FILTER"} "$@" | tee "$CROAR_OUT"
+
+echo "[INFO] Running Zig bench"
+# Prefer same dataset directory for Zig if provided
+if [[ -n "$DATA_ARG" ]]; then
+  zig build -Doptimize=ReleaseFast bench -- "$DATA_ARG" 2>&1 | tee "$ZIG_OUT"
+else
+  # Use the same default dataset as CRoaring's bench
+  zig build -Doptimize=ReleaseFast bench -- "$CROARING_DIR/benchmarks/realdata/census1881" 2>&1 | tee "$ZIG_OUT"
+fi
+
+echo "[INFO] Comparing results (ns per iteration)"
+# Parse both outputs via awk and join by benchmark name in-memory
+awk '
+  FNR==1 { fi++ }
+  $3=="ns" {
+    name=$1; t=$2+0
+    if (fi==1) c[name]=t; else if (fi==2) z[name]=t
+  }
+  END {
+    for (n in c) if (n in z) printf "%s %d %d\n", n, c[n], z[n]
+  }
+' "$CROAR_OUT" "$ZIG_OUT" | sort > "$TMP_DIR/joined.txt"
+
+echo "$(printf '%-36s %12s   %12s   %8s' 'Benchmark' 'CRoaring(ns)' 'Zig(ns)' 'Zig/CR')"
+echo "$(printf '%-36s %12s   %12s   %8s' '---------' '-----------' '-------' '-----')"
+awk '{name=$1; c=$2; z=$3; ratio=(c>0? z/c: 0); printf("%-36s %12d   %12d   %7.2fx\n", name, c, z, ratio)}' "$TMP_DIR/joined.txt"
 
 echo "[INFO] Done."

--- a/run_croaring_microbench.sh
+++ b/run_croaring_microbench.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build and run CRoaring microbenchmarks using zig cc/c++.
+#
+# Usage:
+#   ./run_croaring_microbench.sh [DATA_DIR] [google-benchmark args]
+#
+# Notes:
+# - Clones CRoaring into .deps/CRoaring if missing; otherwise updates it.
+# - Builds with CMake in .deps/CRoaring/build-zig using zig cc/c++.
+# - Builds only the 'bench' target and runs it.
+# - By default, filters out benchmarks whose names contain 'cpp' or 'Cpp'.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CROARING_REMOTE="https://github.com/RoaringBitmap/CRoaring.git"
+CROARING_DIR="$SCRIPT_DIR/tmp-croaring"
+BUILD_DIR="$CROARING_DIR/build-zig"
+BUILD_TYPE="Release"
+
+mkdir -p "$(dirname "$CROARING_DIR")"
+
+if [[ -d "$CROARING_DIR/.git" ]]; then
+  echo "[INFO] Updating CRoaring at $CROARING_DIR"
+  git -C "$CROARING_DIR" fetch --tags --prune
+  git -C "$CROARING_DIR" pull --ff-only || true
+else
+  echo "[INFO] Cloning CRoaring into $CROARING_DIR"
+  git clone --depth=1 "$CROARING_REMOTE" "$CROARING_DIR"
+fi
+
+# Prefer Ninja if available
+GENERATOR_SWITCHES=""
+if command -v ninja >/dev/null 2>&1; then
+  GENERATOR_SWITCHES="-G Ninja"
+fi
+
+# Ensure zig is available
+if ! command -v zig >/dev/null 2>&1; then
+  echo "[ERROR] zig not found in PATH. Install zig and retry." >&2
+  exit 1
+fi
+
+# Configure with CMake using zig as the C/C++ compiler
+mkdir -p "$BUILD_DIR"
+echo "[INFO] Configuring CMake in $BUILD_DIR (BUILD_TYPE=$BUILD_TYPE)"
+CC="zig cc" CXX="zig c++" \
+  cmake -S "$CROARING_DIR" -B "$BUILD_DIR" \
+  $GENERATOR_SWITCHES \
+  -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
+  -DENABLE_ROARING_MICROBENCHMARKS=ON
+
+# Build microbenchmarks (C-only by default: build 'bench' target)
+echo "[INFO] Building microbenchmarks (bench only)"
+cmake --build "$BUILD_DIR" --config "$BUILD_TYPE" --target bench --parallel
+
+# Locate executables (handle generator differences)
+BENCH_BIN="$BUILD_DIR/microbenchmarks/bench"
+[[ -x "$BUILD_DIR/bench" ]] && BENCH_BIN="$BUILD_DIR/bench"
+
+if [[ ! -x "$BENCH_BIN" ]]; then
+  echo "[ERROR] bench executable not found (looked in $BUILD_DIR)" >&2
+  exit 1
+fi
+
+# Run benchmarks
+echo "[INFO] Running bench (realdata)"
+
+# Parse args: optional first positional DATA_DIR if it is a directory
+DATA_ARG=""
+if [[ $# -gt 0 && -d "$1" && "$1" != -* ]]; then
+  DATA_ARG="$1"
+  shift
+  echo "[INFO] Using DATA_DIR=$DATA_ARG"
+fi
+
+# Add default filter unless user provided one
+HAS_FILTER=0
+for a in "$@"; do
+  if [[ "$a" == --benchmark_filter* ]]; then
+    HAS_FILTER=1
+    break
+  fi
+done
+DEFAULT_FILTER=""
+if [[ $HAS_FILTER -eq 0 ]]; then
+  # POSIX ERE: include only non-C++ microbenchmarks by explicit allowlist
+  DEFAULT_FILTER='--benchmark_filter=^(SuccessiveIntersection(64|Cardinality(64)?)?|SuccessiveUnion(Cardinality(64)?|64)?|SuccessiveDifferenceCardinality(64)?|TotalUnion(Heap)?|RandomAccess(64)?|ToArray(64)?|IterateAll(64)?|ComputeCardinality(64)?|RankMany(Slow)?)$'
+fi
+
+"$BENCH_BIN" ${DATA_ARG:++"$DATA_ARG"} ${DEFAULT_FILTER:+"$DEFAULT_FILTER"} "$@"
+
+echo "[INFO] Done."

--- a/src/roaring.zig
+++ b/src/roaring.zig
@@ -630,6 +630,11 @@ pub const Bitmap = extern struct {
         return out;
     }
 
+    /// Copy all values into `out`. Length of `out` must be >= `cardinality()`.
+    pub fn toUint32Array(self: *const Bitmap, out: []u32) void {
+        c.roaring_bitmap_to_uint32_array(conv(self), out.ptr);
+    }
+
     //============================= Optimization =============================//
     /// Remove run-length encoding even when it is more space efficient.
     /// Return whether a change was applied.

--- a/src/roaring64.zig
+++ b/src/roaring64.zig
@@ -15,7 +15,7 @@
 /// - The iterator for 64-bit bitmaps allocates; you must call `Iterator.free()`.
 ///
 const std = @import("std");
-const roaring = @import("roaring.zig");
+const roaring = @import("roaring");
 const c = @cImport({
     @cInclude("roaring.h");
 });

--- a/src/roaring64.zig
+++ b/src/roaring64.zig
@@ -402,6 +402,11 @@ pub const Bitmap64 = opaque {
         return out;
     }
 
+    /// Copy all values into `out`. Length must be >= `cardinality()`.
+    pub fn toUint64Array(self: *const Bitmap64, out: []u64) void {
+        c.roaring64_bitmap_to_uint64_array(conv(self), out.ptr);
+    }
+
     //================================ Iteration ===============================//
 
     /// Iterate with a callback. Returns true if the callback returned true throughout.


### PR DESCRIPTION
## Summary
- Add microbench/bench.zig runner with CRoaring-like output (Time, Iterations)
- Support dataset arg after `--`; default to census1881 when omitted
- Add `--bench`/`-b` substring filter to select which benchmarks run
- Implement ToArray/ToArray64 via CRoaring APIs with preallocated buffers
- Wire new `bench` step in build.zig and forward args to executable
- Update README with instructions and filtering example

## Test plan
- Built and ran in ReleaseFast with various datasets
- Verified output structure and timings comparable to CRoaring

Numbers are mostly at par with CRoaring, which nicely shows the beauty of Zig!