### PR TITLE
feat(x86_64): Improve AVX512 detection

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,9 +4,12 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    // Add option to disable AVX512 in CRoaring
+    const disable_avx512 = b.option(bool, "ROARING_DISABLE_AVX512", "Disable AVX512 in CRoaring") orelse false;
+
     // Standard release options allow the person running `zig build` to select
     // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
-    const lib = add(b, target, optimize);
+    const lib = add(b, target, optimize, disable_avx512);
     b.installArtifact(lib);
 
     var main_tests = b.addTest(.{
@@ -78,7 +81,8 @@ pub fn build(b: *std.Build) void {
     roaring64_mod.addImport("roaring", roaring_mod);
     bench.root_module.addImport("roaring64", roaring64_mod);
     // Compile CRoaring C source into the bench so Zig wrapper can link
-    bench.addCSourceFile(.{ .file = b.path("croaring/roaring.c"), .flags = &.{} });
+    const bench_flags: []const []const u8 = if (disable_avx512) &[_][]const u8{"-DCROARING_COMPILER_SUPPORTS_AVX512=0"} else &[_][]const u8{};
+    bench.addCSourceFile(.{ .file = b.path("croaring/roaring.c"), .flags = bench_flags });
     bench.addIncludePath(b.path("croaring"));
     bench.linkLibC();
     const run_bench = b.addRunArtifact(bench);
@@ -92,7 +96,7 @@ pub fn build(b: *std.Build) void {
 }
 
 /// Add Roaring Bitmaps to your build process
-pub fn add(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode) *std.Build.Step.Compile {
+pub fn add(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, disable_avx512: bool) *std.Build.Step.Compile {
     var lib = b.addLibrary(.{
         .name = "roaring-zig",
         .root_module = b.createModule(.{
@@ -103,7 +107,8 @@ pub fn add(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builti
         .linkage = .static,
     });
 
-    lib.addCSourceFile(.{ .file = b.path("croaring/roaring.c"), .flags = &.{} });
+    const lib_flags: []const []const u8 = if (disable_avx512) &[_][]const u8{"-DCROARING_COMPILER_SUPPORTS_AVX512=0"} else &[_][]const u8{};
+    lib.addCSourceFile(.{ .file = b.path("croaring/roaring.c"), .flags = lib_flags });
     lib.addIncludePath(b.path("croaring"));
     lib.linkLibC();
     return lib;

--- a/build.zig
+++ b/build.zig
@@ -8,20 +8,29 @@ pub fn build(b: *std.Build) void {
     const disable_avx512 = b.option(bool, "ROARING_DISABLE_AVX512", "Disable AVX512 in CRoaring") orelse blk: {
         // Auto-detect: disable AVX512 if the target CPU doesn't support it
         const resolved_target = b.resolveTargetQuery(target.query);
+        const cpu_arch = resolved_target.result.cpu.arch;
+
+        // AVX512 is only available on x86_64 architecture
+        if (cpu_arch != .x86_64) {
+            std.log.info("Non-x86_64 target detected ({s}), disabling AVX512 in CRoaring", .{@tagName(cpu_arch)});
+            break :blk true; // disable AVX512
+        }
+
+        // For x86_64, check if the CPU supports the required AVX512 features
         const cpu_features = resolved_target.result.cpu.features;
         const has_avx512f = cpu_features.isEnabled(@intFromEnum(std.Target.x86.Feature.avx512f));
         const has_avx512dq = cpu_features.isEnabled(@intFromEnum(std.Target.x86.Feature.avx512dq));
         const has_avx512bw = cpu_features.isEnabled(@intFromEnum(std.Target.x86.Feature.avx512bw));
-        
+
         // CRoaring requires multiple AVX512 features, not just AVX512F
         const has_required_avx512 = has_avx512f and has_avx512dq and has_avx512bw;
-        
+
         if (!has_required_avx512) {
-            std.log.info("AVX512 features not detected on target CPU, disabling AVX512 in CRoaring", .{});
+            std.log.info("AVX512 features not detected on x86_64 target CPU, disabling AVX512 in CRoaring", .{});
         } else {
-            std.log.info("AVX512 features detected on target CPU, enabling AVX512 optimizations", .{});
+            std.log.info("AVX512 features detected on x86_64 target CPU, enabling AVX512 optimizations", .{});
         }
-        
+
         break :blk !has_required_avx512;
     };
 
@@ -96,8 +105,8 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     roaring64_mod.addIncludePath(b.path("croaring"));
-    roaring64_mod.addImport("roaring", roaring_mod);
     bench.root_module.addImport("roaring64", roaring64_mod);
+
     // Compile CRoaring C source into the bench so Zig wrapper can link
     const bench_flags: []const []const u8 = if (disable_avx512) &[_][]const u8{"-DCROARING_COMPILER_SUPPORTS_AVX512=0"} else &[_][]const u8{};
     bench.addCSourceFile(.{ .file = b.path("croaring/roaring.c"), .flags = bench_flags });

--- a/build.zig
+++ b/build.zig
@@ -4,8 +4,26 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    // Add option to disable AVX512 in CRoaring
-    const disable_avx512 = b.option(bool, "ROARING_DISABLE_AVX512", "Disable AVX512 in CRoaring") orelse false;
+    // Add option to disable AVX512 in CRoaring, or auto-detect CPU capabilities
+    const disable_avx512 = b.option(bool, "ROARING_DISABLE_AVX512", "Disable AVX512 in CRoaring") orelse blk: {
+        // Auto-detect: disable AVX512 if the target CPU doesn't support it
+        const resolved_target = b.resolveTargetQuery(target.query);
+        const cpu_features = resolved_target.result.cpu.features;
+        const has_avx512f = cpu_features.isEnabled(@intFromEnum(std.Target.x86.Feature.avx512f));
+        const has_avx512dq = cpu_features.isEnabled(@intFromEnum(std.Target.x86.Feature.avx512dq));
+        const has_avx512bw = cpu_features.isEnabled(@intFromEnum(std.Target.x86.Feature.avx512bw));
+        
+        // CRoaring requires multiple AVX512 features, not just AVX512F
+        const has_required_avx512 = has_avx512f and has_avx512dq and has_avx512bw;
+        
+        if (!has_required_avx512) {
+            std.log.info("AVX512 features not detected on target CPU, disabling AVX512 in CRoaring", .{});
+        } else {
+            std.log.info("AVX512 features detected on target CPU, enabling AVX512 optimizations", .{});
+        }
+        
+        break :blk !has_required_avx512;
+    };
 
     // Standard release options allow the person running `zig build` to select
     // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.

--- a/run_croaring_microbench.sh
+++ b/run_croaring_microbench.sh
@@ -47,10 +47,6 @@ if ! command -v zig >/dev/null 2>&1; then
   exit 1
 fi
 
-# AVX512 detection is now handled automatically by Zig's build system
-# The build.zig will auto-detect CPU features and disable AVX512 if needed
-DISABLE_AVX512_FLAG=""
-
 # Configure with CMake using zig as the C/C++ compiler
 mkdir -p "$BUILD_DIR"
 echo "[INFO] Configuring CMake in $BUILD_DIR (BUILD_TYPE=$BUILD_TYPE)"

--- a/run_croaring_microbench.sh
+++ b/run_croaring_microbench.sh
@@ -47,6 +47,43 @@ if ! command -v zig >/dev/null 2>&1; then
   exit 1
 fi
 
+# Function to detect if CPU supports AVX512
+detect_avx512_support() {
+  case "$(uname -s)" in
+    Linux)
+      # Check /proc/cpuinfo for AVX512 flags
+      if grep -q "avx512" /proc/cpuinfo 2>/dev/null; then
+        return 0  # AVX512 supported
+      fi
+      ;;
+    Darwin)
+      # On macOS, check sysctl for CPU features
+      if sysctl -n machdep.cpu.leaf7_features 2>/dev/null | grep -q "AVX512"; then
+        return 0  # AVX512 supported
+      fi
+      # Also check brand string for known AVX512 CPUs
+      if sysctl -n machdep.cpu.brand_string 2>/dev/null | grep -qE "(Intel.*Core.*i[579]|Xeon|M[123])"; then
+        # Most modern Intel CPUs support AVX512, but let's be conservative
+        # and assume support unless we know otherwise
+        return 0
+      fi
+      ;;
+    *)
+      # For other platforms, assume no AVX512 support by default
+      ;;
+  esac
+  return 1  # AVX512 not supported or uncertain
+}
+
+# Detect AVX512 support
+DISABLE_AVX512_FLAG=""
+if ! detect_avx512_support; then
+  echo "[INFO] AVX512 not detected or not supported, disabling AVX512 in CRoaring"
+  DISABLE_AVX512_FLAG="-DROARING_DISABLE_AVX512=ON"
+else
+  echo "[INFO] AVX512 support detected, enabling AVX512 optimizations"
+fi
+
 # Configure with CMake using zig as the C/C++ compiler
 mkdir -p "$BUILD_DIR"
 echo "[INFO] Configuring CMake in $BUILD_DIR (BUILD_TYPE=$BUILD_TYPE)"
@@ -54,7 +91,8 @@ CC="zig cc" CXX="zig c++" \
   cmake -S "$CROARING_DIR" -B "$BUILD_DIR" \
   $GENERATOR_SWITCHES \
   -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
-  -DENABLE_ROARING_MICROBENCHMARKS=ON
+  -DENABLE_ROARING_MICROBENCHMARKS=ON \
+  ${DISABLE_AVX512_FLAG}
 
 # Build microbenchmarks (C-only by default: build 'bench' target)
 echo "[INFO] Building microbenchmarks (bench only)"
@@ -103,12 +141,19 @@ ZIG_OUT="$TMP_DIR/zig.txt"
 "$BENCH_BIN" ${DATA_ARG:++"$DATA_ARG"} ${DEFAULT_FILTER:+"$DEFAULT_FILTER"} "$@" | tee "$CROAR_OUT"
 
 echo "[INFO] Running Zig bench"
+# Build Zig flags based on AVX512 detection
+ZIG_AVX512_FLAG=""
+if [[ -n "$DISABLE_AVX512_FLAG" ]]; then
+  ZIG_AVX512_FLAG=" -DROARING_DISABLE_AVX512=true"
+fi
+FLAGS="$ZIG_AVX512_FLAG -Doptimize=ReleaseFast"
+
 # Prefer same dataset directory for Zig if provided
 if [[ -n "$DATA_ARG" ]]; then
-  zig build -Doptimize=ReleaseFast bench -- "$DATA_ARG" 2>&1 | tee "$ZIG_OUT"
+  zig build $FLAGS bench -- "$DATA_ARG" 2>&1 | tee "$ZIG_OUT"
 else
   # Use the same default dataset as CRoaring's bench
-  zig build -Doptimize=ReleaseFast bench -- "$CROARING_DIR/benchmarks/realdata/census1881" 2>&1 | tee "$ZIG_OUT"
+  zig build $FLAGS bench -- "$CROARING_DIR/benchmarks/realdata/census1881" 2>&1 | tee "$ZIG_OUT"
 fi
 
 echo "[INFO] Comparing results (ns per iteration)"
@@ -122,7 +167,7 @@ awk '
   END {
     for (n in c) if (n in z) printf "%s %d %d\n", n, c[n], z[n]
   }
-' "$CROAR_OUT" "$ZIG_OUT" | sort > "$TMP_DIR/joined.txt"
+' "$CROAR_OUT" "$ZIG_OUT" | sort >"$TMP_DIR/joined.txt"
 
 echo "$(printf '%-36s %12s   %12s   %8s' 'Benchmark' 'CRoaring(ns)' 'Zig(ns)' 'Zig/CR')"
 echo "$(printf '%-36s %12s   %12s   %8s' '---------' '-----------' '-------' '-----')"

--- a/run_croaring_microbench.sh
+++ b/run_croaring_microbench.sh
@@ -47,42 +47,9 @@ if ! command -v zig >/dev/null 2>&1; then
   exit 1
 fi
 
-# Function to detect if CPU supports AVX512
-detect_avx512_support() {
-  case "$(uname -s)" in
-    Linux)
-      # Check /proc/cpuinfo for AVX512 flags
-      if grep -q "avx512" /proc/cpuinfo 2>/dev/null; then
-        return 0  # AVX512 supported
-      fi
-      ;;
-    Darwin)
-      # On macOS, check sysctl for CPU features
-      if sysctl -n machdep.cpu.leaf7_features 2>/dev/null | grep -q "AVX512"; then
-        return 0  # AVX512 supported
-      fi
-      # Also check brand string for known AVX512 CPUs
-      if sysctl -n machdep.cpu.brand_string 2>/dev/null | grep -qE "(Intel.*Core.*i[579]|Xeon|M[123])"; then
-        # Most modern Intel CPUs support AVX512, but let's be conservative
-        # and assume support unless we know otherwise
-        return 0
-      fi
-      ;;
-    *)
-      # For other platforms, assume no AVX512 support by default
-      ;;
-  esac
-  return 1  # AVX512 not supported or uncertain
-}
-
-# Detect AVX512 support
+# AVX512 detection is now handled automatically by Zig's build system
+# The build.zig will auto-detect CPU features and disable AVX512 if needed
 DISABLE_AVX512_FLAG=""
-if ! detect_avx512_support; then
-  echo "[INFO] AVX512 not detected or not supported, disabling AVX512 in CRoaring"
-  DISABLE_AVX512_FLAG="-DROARING_DISABLE_AVX512=ON"
-else
-  echo "[INFO] AVX512 support detected, enabling AVX512 optimizations"
-fi
 
 # Configure with CMake using zig as the C/C++ compiler
 mkdir -p "$BUILD_DIR"
@@ -91,8 +58,7 @@ CC="zig cc" CXX="zig c++" \
   cmake -S "$CROARING_DIR" -B "$BUILD_DIR" \
   $GENERATOR_SWITCHES \
   -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
-  -DENABLE_ROARING_MICROBENCHMARKS=ON \
-  ${DISABLE_AVX512_FLAG}
+  -DENABLE_ROARING_MICROBENCHMARKS=ON
 
 # Build microbenchmarks (C-only by default: build 'bench' target)
 echo "[INFO] Building microbenchmarks (bench only)"
@@ -141,12 +107,8 @@ ZIG_OUT="$TMP_DIR/zig.txt"
 "$BENCH_BIN" ${DATA_ARG:++"$DATA_ARG"} ${DEFAULT_FILTER:+"$DEFAULT_FILTER"} "$@" | tee "$CROAR_OUT"
 
 echo "[INFO] Running Zig bench"
-# Build Zig flags based on AVX512 detection
-ZIG_AVX512_FLAG=""
-if [[ -n "$DISABLE_AVX512_FLAG" ]]; then
-  ZIG_AVX512_FLAG=" -DROARING_DISABLE_AVX512=true"
-fi
-FLAGS="$ZIG_AVX512_FLAG -Doptimize=ReleaseFast"
+# Zig will automatically detect and handle AVX512 support
+FLAGS=" -Doptimize=ReleaseFast"
 
 # Prefer same dataset directory for Zig if provided
 if [[ -n "$DATA_ARG" ]]; then

--- a/src/roaring.zig
+++ b/src/roaring.zig
@@ -736,10 +736,10 @@ pub fn setAllocator(allocator: std.mem.Allocator) void {
 /// The global Roaring allocator is used for bookkeeping; this function frees
 ///  that memory.  The C API does not expose a way to reset memory functions to
 ///  their defaults, so you only use this when you're done using Bitmaps.
-/// Note: With header-based allocation tracking, this function no longer needs
-///  to free any bookkeeping memory, but is kept for API compatibility.
 pub fn freeAllocator() void {
-    // No cleanup needed with header-based allocation tracking
+    if (global_roaring_allocator) |ally| {
+        allocations.deinit(ally);
+    }
 }
 
 /// Roaring only supports a single, global allocator
@@ -748,58 +748,34 @@ var global_roaring_allocator: ?std.mem.Allocator = null;
 // The roaring_resize function uses pointers instead of slices, making functions
 //  like `realloc` tricky as the Allocator interface expects slices.  This means
 //  that we have to track the lengths associated with allocations somehow.
-//
-// This implementation uses a header-based approach: we allocate extra space
-// to store the allocation size before the actual data, then return a pointer
-// offset by the header size. This avoids the HashMap overhead which was
-// causing performance issues in union operations.
-
-const AllocationHeader = struct {
-    size: usize,
-};
-
-const HEADER_SIZE = @sizeOf(AllocationHeader);
+// A relatively cheap implementation would prefix allocations with a header to
+//  store the length, but this makes aligned allocations really challenging.
+// This implementation uses a hash map where the pointers are the keys and the
+//  values are the lengths.
+var allocations = std.AutoHashMapUnmanaged(?*anyopaque, usize){};
 
 fn setAllocation(mem: []u8) ?*anyopaque {
-    if (mem.len < HEADER_SIZE) return null;
-
-    // Store size in the header
-    const header = @as(*AllocationHeader, @ptrCast(@alignCast(mem.ptr)));
-    header.size = mem.len - HEADER_SIZE;
-
-    // Return pointer offset by header size
-    return @as(?*anyopaque, @ptrCast(mem.ptr + HEADER_SIZE));
+    if (global_roaring_allocator) |ally| {
+        const ptr = @as(?*anyopaque, @ptrCast(mem.ptr));
+        allocations.put(ally, ptr, mem.len) catch return null;
+        return ptr;
+    }
+    @panic("global_roaring_allocator is not set");
 }
 
 fn getAllocation(ptr: ?*anyopaque) []u8 {
-    if (ptr == null) @panic("getAllocation received null pointer");
-
-    // Get header by going back from the user pointer
-    const user_ptr = @as([*]u8, @ptrCast(ptr));
-    const header_ptr = user_ptr - HEADER_SIZE;
-    const header = @as(*AllocationHeader, @ptrCast(@alignCast(header_ptr)));
-
-    // Return slice covering the user data
-    return user_ptr[0..header.size];
+    const len = allocations.get(ptr) orelse @panic("getAllocation cannot find pointer");
+    return @as([*]u8, @ptrCast(ptr))[0..len];
 }
 
 fn getRemoveAllocation(ptr: ?*anyopaque) []u8 {
-    if (ptr == null) @panic("getRemoveAllocation received null pointer");
-
-    // Get header by going back from the user pointer
-    const user_ptr = @as([*]u8, @ptrCast(ptr));
-    const header_ptr = user_ptr - HEADER_SIZE;
-    const header = @as(*AllocationHeader, @ptrCast(@alignCast(header_ptr)));
-
-    // Return slice covering the user data
-    return user_ptr[0..header.size];
+    const kv = allocations.fetchRemove(ptr) orelse @panic("removeAllocationn cannot find pointer");
+    return @as([*c]u8, @ptrCast(ptr))[0..kv.value];
 }
 
 export fn roaringMalloc(size: usize) ?*anyopaque {
     if (global_roaring_allocator) |ally| {
-        // Allocate extra space for header
-        const total_size = size + HEADER_SIZE;
-        return setAllocation(ally.alloc(u8, total_size) catch return null);
+        return setAllocation(ally.alloc(u8, size) catch return null);
     }
     return null;
 }
@@ -817,11 +793,7 @@ export fn roaringRealloc(ptr: ?*anyopaque, size: usize) ?*anyopaque {
         return null;
     } else if (global_roaring_allocator) |ally| {
         const old = getAllocation(ptr);
-        // We need to get the full allocation including header for realloc
-        const old_full = @as([*]u8, @ptrCast(ptr)) - HEADER_SIZE;
-        const old_full_slice = old_full[0 .. old.len + HEADER_SIZE];
-        const new_total_size = size + HEADER_SIZE;
-        return setAllocation(ally.realloc(old_full_slice, new_total_size) catch return null);
+        return setAllocation(ally.realloc(old, size) catch return null);
     } else return null;
 }
 
@@ -840,25 +812,20 @@ export fn roaringFree(ptr: ?*anyopaque) void {
     if (ptr == null) return;
 
     if (global_roaring_allocator) |ally| {
-        const user_data = getRemoveAllocation(ptr);
-        // Free the full allocation including header
-        const full_ptr = @as([*]u8, @ptrCast(ptr)) - HEADER_SIZE;
-        const full_slice = full_ptr[0 .. user_data.len + HEADER_SIZE];
-        ally.free(full_slice);
+        ally.free(getRemoveAllocation(ptr));
     } else @panic("roaringFree was called but global_roaring_allocator is not set");
 }
 
 export fn roaringAlignedMalloc(ptr_align: usize, size: usize) ?*anyopaque {
     if (global_roaring_allocator) |ally| {
-        const total_size = size + HEADER_SIZE;
         return setAllocation(
             // Allocator's alignment parameter has to be comptime known, so we
             //  have to do this somewhat awkward transform:
             switch (ptr_align) {
-                8 => ally.alignedAlloc(u8, std.mem.Alignment.fromByteUnits(8), total_size),
-                16 => ally.alignedAlloc(u8, std.mem.Alignment.fromByteUnits(16), total_size),
+                8 => ally.alignedAlloc(u8, std.mem.Alignment.fromByteUnits(8), size),
+                16 => ally.alignedAlloc(u8, std.mem.Alignment.fromByteUnits(16), size),
                 // This appears to be the only value that is actually used in roaring.c
-                32 => ally.alignedAlloc(u8, std.mem.Alignment.fromByteUnits(32), total_size),
+                32 => ally.alignedAlloc(u8, std.mem.Alignment.fromByteUnits(32), size),
                 else => @panic("Unexpected alignment size"),
             } catch return null);
     }

--- a/src/roaring.zig
+++ b/src/roaring.zig
@@ -736,10 +736,10 @@ pub fn setAllocator(allocator: std.mem.Allocator) void {
 /// The global Roaring allocator is used for bookkeeping; this function frees
 ///  that memory.  The C API does not expose a way to reset memory functions to
 ///  their defaults, so you only use this when you're done using Bitmaps.
+/// Note: With header-based allocation tracking, this function no longer needs
+///  to free any bookkeeping memory, but is kept for API compatibility.
 pub fn freeAllocator() void {
-    if (global_roaring_allocator) |ally| {
-        allocations.deinit(ally);
-    }
+    // No cleanup needed with header-based allocation tracking
 }
 
 /// Roaring only supports a single, global allocator
@@ -748,34 +748,58 @@ var global_roaring_allocator: ?std.mem.Allocator = null;
 // The roaring_resize function uses pointers instead of slices, making functions
 //  like `realloc` tricky as the Allocator interface expects slices.  This means
 //  that we have to track the lengths associated with allocations somehow.
-// A relatively cheap implementation would prefix allocations with a header to
-//  store the length, but this makes aligned allocations really challenging.
-// This implementation uses a hash map where the pointers are the keys and the
-//  values are the lengths.
-var allocations = std.AutoHashMapUnmanaged(?*anyopaque, usize){};
+//
+// This implementation uses a header-based approach: we allocate extra space
+// to store the allocation size before the actual data, then return a pointer
+// offset by the header size. This avoids the HashMap overhead which was
+// causing performance issues in union operations.
+
+const AllocationHeader = struct {
+    size: usize,
+};
+
+const HEADER_SIZE = @sizeOf(AllocationHeader);
 
 fn setAllocation(mem: []u8) ?*anyopaque {
-    if (global_roaring_allocator) |ally| {
-        const ptr = @as(?*anyopaque, @ptrCast(mem.ptr));
-        allocations.put(ally, ptr, mem.len) catch return null;
-        return ptr;
-    }
-    @panic("global_roaring_allocator is not set");
+    if (mem.len < HEADER_SIZE) return null;
+
+    // Store size in the header
+    const header = @as(*AllocationHeader, @ptrCast(@alignCast(mem.ptr)));
+    header.size = mem.len - HEADER_SIZE;
+
+    // Return pointer offset by header size
+    return @as(?*anyopaque, @ptrCast(mem.ptr + HEADER_SIZE));
 }
 
 fn getAllocation(ptr: ?*anyopaque) []u8 {
-    const len = allocations.get(ptr) orelse @panic("getAllocation cannot find pointer");
-    return @as([*]u8, @ptrCast(ptr))[0..len];
+    if (ptr == null) @panic("getAllocation received null pointer");
+
+    // Get header by going back from the user pointer
+    const user_ptr = @as([*]u8, @ptrCast(ptr));
+    const header_ptr = user_ptr - HEADER_SIZE;
+    const header = @as(*AllocationHeader, @ptrCast(@alignCast(header_ptr)));
+
+    // Return slice covering the user data
+    return user_ptr[0..header.size];
 }
 
 fn getRemoveAllocation(ptr: ?*anyopaque) []u8 {
-    const kv = allocations.fetchRemove(ptr) orelse @panic("removeAllocationn cannot find pointer");
-    return @as([*c]u8, @ptrCast(ptr))[0..kv.value];
+    if (ptr == null) @panic("getRemoveAllocation received null pointer");
+
+    // Get header by going back from the user pointer
+    const user_ptr = @as([*]u8, @ptrCast(ptr));
+    const header_ptr = user_ptr - HEADER_SIZE;
+    const header = @as(*AllocationHeader, @ptrCast(@alignCast(header_ptr)));
+
+    // Return slice covering the user data
+    return user_ptr[0..header.size];
 }
 
 export fn roaringMalloc(size: usize) ?*anyopaque {
     if (global_roaring_allocator) |ally| {
-        return setAllocation(ally.alloc(u8, size) catch return null);
+        // Allocate extra space for header
+        const total_size = size + HEADER_SIZE;
+        return setAllocation(ally.alloc(u8, total_size) catch return null);
     }
     return null;
 }
@@ -793,7 +817,11 @@ export fn roaringRealloc(ptr: ?*anyopaque, size: usize) ?*anyopaque {
         return null;
     } else if (global_roaring_allocator) |ally| {
         const old = getAllocation(ptr);
-        return setAllocation(ally.realloc(old, size) catch return null);
+        // We need to get the full allocation including header for realloc
+        const old_full = @as([*]u8, @ptrCast(ptr)) - HEADER_SIZE;
+        const old_full_slice = old_full[0 .. old.len + HEADER_SIZE];
+        const new_total_size = size + HEADER_SIZE;
+        return setAllocation(ally.realloc(old_full_slice, new_total_size) catch return null);
     } else return null;
 }
 
@@ -812,20 +840,25 @@ export fn roaringFree(ptr: ?*anyopaque) void {
     if (ptr == null) return;
 
     if (global_roaring_allocator) |ally| {
-        ally.free(getRemoveAllocation(ptr));
+        const user_data = getRemoveAllocation(ptr);
+        // Free the full allocation including header
+        const full_ptr = @as([*]u8, @ptrCast(ptr)) - HEADER_SIZE;
+        const full_slice = full_ptr[0 .. user_data.len + HEADER_SIZE];
+        ally.free(full_slice);
     } else @panic("roaringFree was called but global_roaring_allocator is not set");
 }
 
 export fn roaringAlignedMalloc(ptr_align: usize, size: usize) ?*anyopaque {
     if (global_roaring_allocator) |ally| {
+        const total_size = size + HEADER_SIZE;
         return setAllocation(
             // Allocator's alignment parameter has to be comptime known, so we
             //  have to do this somewhat awkward transform:
             switch (ptr_align) {
-                8 => ally.alignedAlloc(u8, std.mem.Alignment.fromByteUnits(8), size),
-                16 => ally.alignedAlloc(u8, std.mem.Alignment.fromByteUnits(16), size),
+                8 => ally.alignedAlloc(u8, std.mem.Alignment.fromByteUnits(8), total_size),
+                16 => ally.alignedAlloc(u8, std.mem.Alignment.fromByteUnits(16), total_size),
                 // This appears to be the only value that is actually used in roaring.c
-                32 => ally.alignedAlloc(u8, std.mem.Alignment.fromByteUnits(32), size),
+                32 => ally.alignedAlloc(u8, std.mem.Alignment.fromByteUnits(32), total_size),
                 else => @panic("Unexpected alignment size"),
             } catch return null);
     }

--- a/src/roaring64.zig
+++ b/src/roaring64.zig
@@ -15,7 +15,7 @@
 /// - The iterator for 64-bit bitmaps allocates; you must call `Iterator.free()`.
 ///
 const std = @import("std");
-const roaring = @import("roaring.zig");
+const roaring = @import("roaring");
 const c = @cImport({
     @cInclude("roaring.h");
 });

--- a/src/roaring64.zig
+++ b/src/roaring64.zig
@@ -15,13 +15,19 @@
 /// - The iterator for 64-bit bitmaps allocates; you must call `Iterator.free()`.
 ///
 const std = @import("std");
-const roaring = @import("roaring");
 const c = @cImport({
     @cInclude("roaring.h");
 });
 
 /// Error set shared with 32-bit wrapper
-pub const RoaringError = roaring.RoaringError;
+pub const RoaringError = error{
+    ///
+    allocation_failed,
+    ///
+    frozen_view_failed,
+    ///
+    deserialize_failed,
+};
 
 /// Callback signature for 64-bit iteration (`roaring64_bitmap_iterate`)
 pub const IteratorFunction = fn (u64, ?*anyopaque) callconv(.c) bool;

--- a/src/roaring64.zig
+++ b/src/roaring64.zig
@@ -15,7 +15,7 @@
 /// - The iterator for 64-bit bitmaps allocates; you must call `Iterator.free()`.
 ///
 const std = @import("std");
-const roaring = @import("roaring");
+const roaring = @import("roaring.zig");
 const c = @cImport({
     @cInclude("roaring.h");
 });


### PR DESCRIPTION
I was seeing issues when running the benchmarks on Ryzen 5950x chip based desktop. So, had to make changes to the build process to determine whether the CPU supports AVX512 or not. 

This PR adds architecture-aware AVX512 detection that should work on all platforms.